### PR TITLE
Stop space-bar toggle from scrolling the page

### DIFF
--- a/angular-toggle-switch.js
+++ b/angular-toggle-switch.js
@@ -52,6 +52,7 @@
           var key = e.which ? e.which : e.keyCode;
           if (key === KEY_SPACE) {
             scope.$apply(scope.toggle);
+            $event.preventDefault();
           }
         });
 


### PR DESCRIPTION
Issue is that: on a key press (space-bar) event, a long page will also scrolls down.
this is annoying because the form can scroll out of view.  Fix: marks the event as having been handled and stops the default bubbling up the event to the page.
